### PR TITLE
Fix file conflicts with YARP

### DIFF
--- a/example/idl/rosPortable/CMakeLists.txt
+++ b/example/idl/rosPortable/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-find_package(YARP COMPONENTS os idl_tools REQUIRED)
+find_package(YARP COMPONENTS os idl_tools rosmsg REQUIRED)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,13 +11,6 @@ add_subdirectory(libYARP_wire_rep_utils)
 add_subdirectory(carriers)
 
 if(YARP_COMPILE_EXECUTABLES)
-    # idl compilers (thrift and ros)
+    # ros idl compiler
     add_subdirectory(yarpidl_rosmsg)
-    if(NOT CREATE_SHARED_LIBS)
-        include(YarpInstallBasicPackageFiles)
-        yarp_install_basic_package_files(
-          YARP_idl_tools
-          INCLUDE_CONTENT "include(\"\\\${YARP_MODULE_DIR}/YarpIDL.cmake\")"
-        )
-    endif()
 endif()

--- a/src/carriers/CMakeLists.txt
+++ b/src/carriers/CMakeLists.txt
@@ -5,7 +5,7 @@
 include(YarpPlugin)
 include(YarpPrintFeature)
 
-yarp_begin_plugin_library(yarpcar
+yarp_begin_plugin_library(yarpcarros
   OPTION YARP_COMPILE_CARRIER_PLUGINS
   DEFAULT ON
 )
@@ -13,22 +13,22 @@ yarp_begin_plugin_library(yarpcar
 add_subdirectory(xmlrpc_carrier)
 add_subdirectory(tcpros_carrier)
 
-yarp_end_plugin_library(yarpcar QUIET)
-add_library(YARP::yarpcar ALIAS yarpcar)
+yarp_end_plugin_library(yarpcarros QUIET)
+add_library(YARP::yarpcarros ALIAS yarpcarros)
 
 install(
-  TARGETS yarpcar
-  EXPORT YARP_yarpcar
-  COMPONENT yarpcar
+  TARGETS yarpcarros
+  EXPORT YARP_yarpcarros
+  COMPONENT yarpcarros
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 )
 
 include(YarpInstallBasicPackageFiles)
-yarp_install_basic_package_files(YARP_yarpcar
-  DEPENDENCIES ${YARP_yarpcar_PUBLIC_DEPS}
-  PRIVATE_DEPENDENCIES ${YARP_yarpcar_PRIVATE_DEPS}
+yarp_install_basic_package_files(YARP_yarpcarros
+  DEPENDENCIES ${YARP_yarpcarros_PUBLIC_DEPS}
+  PRIVATE_DEPENDENCIES ${YARP_yarpcarros_PRIVATE_DEPS}
 )
 
-set_property(TARGET yarpcar PROPERTY FOLDER "Plugins/Carrier")
+set_property(TARGET yarpcarros PROPERTY FOLDER "Plugins/Carrier")

--- a/src/yarpidl_rosmsg/CMakeLists.txt
+++ b/src/yarpidl_rosmsg/CMakeLists.txt
@@ -40,8 +40,8 @@ endif()
 
 install(
   TARGETS yarpidl_rosmsg
-  EXPORT YARP_idl_tools
-  COMPONENT YARP_idl_tools
+  EXPORT YARP_rosmsg
+  COMPONENT YARP_rosmsg
   DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 


### PR DESCRIPTION
Before this commit, yarp-ros was overwriting some files that YARP also installed, in particular the yarpcar library and CMake component, and the yarp_idl_tools CMake components. This commit renames the yarpcar library to yarpcarros, and move the YARP::yarpidl_ros target to the rosmsgs YARP CMake component, avoiding any conflict.

This modifications should permit to use yarp-ros in Unstable CI of the robotology superbuild, see https://github.com/robotology/robotology-superbuild/pull/1547 .